### PR TITLE
fix: nextjs issue(Module not found: Package path . is not exported fr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": "./dist/bear-react-carousel.es.js",
       "import": "./dist/bear-react-carousel.es.js"
     },
     "./dist/index.css": "./dist/style.css"


### PR DESCRIPTION
…om package)


>Module not found: Package path . is not exported from package /Users/imagine/project/test/nextjs-bear-carousel/node_modules/bear-react-carousel (see exports field in /Users/imagine/project/test/nextjs-bear-carousel/node_modules/bear-react-carousel/package.json)
